### PR TITLE
Feature/post

### DIFF
--- a/src/comment/comment.controller.ts
+++ b/src/comment/comment.controller.ts
@@ -38,22 +38,22 @@ export class CommentController {
     @Body() editCommentBodyDTO: EditCommentBodyDTO,
     @Req() request: Request,
   ): Promise<GetCommentResponseDTO> {
-    const Comment = await this.commentService.findCommentById(Id);
+    const comment = await this.commentService.findCommentById(Id);
 
-    if (!Comment) {
+    if (!comment) {
       throw new NotFoundException(`${Id}번 Comment가 존재하지 않습니다.`);
     }
 
-    if (!Comment.status) {
+    if (!comment.status) {
       throw new NotAcceptableException('삭제된 Comment입니다.');
     }
 
-    if (Comment.userId !== request.user.Id) {
+    if (comment.userId !== request.user.Id) {
       throw new UnauthorizedException('유효하지 않은 접근입니다.');
     }
 
     const newComment = await this.commentService.editComment(
-      Comment,
+      comment,
       editCommentBodyDTO,
     );
 
@@ -66,17 +66,17 @@ export class CommentController {
     @Param('Id', ValidateIdPipe) Id: number,
     @Req() request: Request,
   ) {
-    const Comment = await this.commentService.findCommentById(Id);
+    const comment = await this.commentService.findCommentById(Id);
 
-    if (!Comment) {
+    if (!comment) {
       throw new NotFoundException(`${Id}번 Comment가 존재하지 않습니다.`);
     }
 
-    if (!Comment.status) {
+    if (!comment.status) {
       throw new NotAcceptableException('삭제된 Comment입니다.');
     }
 
-    if (Comment.userId !== request.user.Id) {
+    if (comment.userId !== request.user.Id) {
       throw new UnauthorizedException('유효하지 않은 접근입니다.');
     }
 
@@ -95,18 +95,18 @@ export class CommentController {
     @Param('Id', ValidateIdPipe) Id: number,
     @Req() request: Request,
   ): Promise<boolean> {
-    const Comment = await this.commentService.findCommentById(Id);
+    const comment = await this.commentService.findCommentById(Id);
 
-    if (!Comment) {
+    if (!comment) {
       throw new NotFoundException(`${Id}번 Comment가 존재하지 않습니다.`);
     }
 
-    if (!Comment.status) {
+    if (!comment.status) {
       throw new NotAcceptableException('삭제된 Comment입니다.');
     }
 
     const isLiked = await this.commentLikeService.checkUserLikedComment(
-      Comment.Id,
+      comment.Id,
       request.user.Id,
     );
 
@@ -118,13 +118,13 @@ export class CommentController {
     @Param('Id', ValidateIdPipe) Id: number,
     @Req() request: Request,
   ) {
-    const Comment = await this.commentService.findCommentById(Id);
+    const comment = await this.commentService.findCommentById(Id);
 
-    if (!Comment) {
+    if (!comment) {
       throw new NotFoundException(`${Id}번 Comment가 존재하지 않습니다.`);
     }
 
-    if (!Comment.status) {
+    if (!comment.status) {
       throw new NotAcceptableException('삭제된 Comment입니다.');
     }
 
@@ -151,29 +151,29 @@ export class CommentController {
     @Body() createCommentBodyDTO: CreateCommentBodyDTO,
     @Req() request: Request,
   ): Promise<GetCommentResponseDTO> {
-    const Comment = await this.commentService.findCommentById(Id);
+    const comment = await this.commentService.findCommentById(Id);
 
-    if (!Comment) {
+    if (!comment) {
       throw new NotFoundException(`${Id}번 Comment가 존재하지 않습니다.`);
     }
 
-    if (!Comment.status) {
+    if (!comment.status) {
       throw new NotAcceptableException('삭제된 Comment입니다.');
     }
 
     const userId = request.user.Id;
-    const postId = Comment.postId;
+    const postId = comment.postId;
     const isReply = true;
 
-    const Reply = await this.commentService.createComment(
+    const reply = await this.commentService.createComment(
       postId,
       userId,
       createCommentBodyDTO,
       isReply,
     );
 
-    this.commentReplyService.addParentChildRelation(Id, Reply.Id);
+    this.commentReplyService.addParentChildRelation(Id, reply.Id);
 
-    return new GetCommentResponseDTO(Reply);
+    return new GetCommentResponseDTO(reply);
   }
 }

--- a/src/comment/comment.service.ts
+++ b/src/comment/comment.service.ts
@@ -31,19 +31,19 @@ export class CommentService {
     createCommentBodyDTO.userId = userId;
     createCommentBodyDTO.isReply = isReply;
 
-    const Comment = this.commentRepository.create(createCommentBodyDTO);
+    const comment = this.commentRepository.create(createCommentBodyDTO);
 
-    await this.commentRepository.save(Comment);
+    await this.commentRepository.save(comment);
 
-    return Comment;
+    return comment;
   }
 
   public async editComment(
-    Comment: CommentEntity,
+    comment: CommentEntity,
     editCommentBodyDTO: EditCommentBodyDTO,
   ): Promise<CommentEntity> {
     const newComment = this.commentRepository.merge(
-      Comment,
+      comment,
       editCommentBodyDTO,
     );
 

--- a/src/comment/comment.service.ts
+++ b/src/comment/comment.service.ts
@@ -57,6 +57,14 @@ export class CommentService {
     return { return: true };
   }
 
+  public async findCommentsByPostId(Id: number): Promise<CommentEntity[]> {
+    const comments = await this.commentRepository.find({
+      where: { postId: Id, isReply: false },
+    });
+
+    return comments;
+  }
+
   public async incrementLikes(Id: number) {
     await this.commentRepository.increment({ Id }, 'likes', 1);
 

--- a/src/comment/dto/get-comment-list-element.dto.ts
+++ b/src/comment/dto/get-comment-list-element.dto.ts
@@ -1,0 +1,14 @@
+import { CommentEntity } from '../comment.entity';
+
+export class GetCommentListElementDTO {
+  public constructor(comment: CommentEntity) {
+    this.content = comment.content;
+    this.userId = comment.userId;
+    this.createdAt = comment.createdAt;
+    this.likes = comment.likes;
+  }
+  public readonly content: string;
+  public readonly userId: number;
+  public readonly createdAt: string;
+  public readonly likes: number;
+}

--- a/src/comment/dto/get-comment-list-response.dto.ts
+++ b/src/comment/dto/get-comment-list-response.dto.ts
@@ -1,0 +1,11 @@
+import { CommentEntity } from '../comment.entity';
+import { GetCommentListElementDTO } from './get-comment-list-element.dto';
+
+export class GetCommentListResponseDTO {
+  public constructor(comments: CommentEntity[]) {
+    this.count = comments.length;
+    this.data = comments.map(comment => new GetCommentListElementDTO(comment));
+  }
+  public readonly count: number;
+  public readonly data: object;
+}

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -26,6 +26,7 @@ import { OnlyMemberGuard } from '../common/guards/only-member.guard';
 import { GetPostListResponseDTO } from './dto/get-post-list-response.dto';
 import { CreateCommentBodyDTO } from '../comment/dto/create-comment-body.dto';
 import { GetCommentResponseDTO } from '../comment/dto/get-comment-response.dto';
+import { GetCommentListResponseDTO } from '../comment/dto/get-comment-list-response.dto';
 
 @Controller('post')
 export class PostController {
@@ -204,6 +205,26 @@ export class PostController {
     );
 
     return new GetCommentResponseDTO(comment);
+  }
+
+  @Get(':Id/comment')
+  @UseGuards(OnlyMemberGuard)
+  async loadAllComments(
+    @Param('Id', ValidateIdPipe) Id: number,
+  ): Promise<GetCommentListResponseDTO> {
+    const post = await this.postService.findPostById(Id);
+
+    if (!post) {
+      throw new NotFoundException(`${Id}번 Post가 존재하지 않습니다.`);
+    }
+
+    if (!post.status) {
+      throw new NotAcceptableException('삭제된 Post입니다.');
+    }
+
+    const comments = await this.commentService.findCommentsByPostId(Id);
+
+    return new GetCommentListResponseDTO(comments);
   }
 
   @Get('')


### PR DESCRIPTION
1. 특정 post의 모든 댓글 불러오는 API 추가
2. Comment, Post 관련 변수명들 소문자로 시작하도록 수정

1번의 경우, 모든 Post를 반환하는 API와 다른 점이 있습니다. 복수 개의 comment를 반환하는 DTO에 사용하기 위해 개별 comment에 대한 생성자를 추가로 만들었다는 점입니다. 이 부분 리뷰해주시면 좋을 것 같습니다. Post 복수 개 리턴하는 경우에도 이런 식으로 바꿀 수 있으니까.